### PR TITLE
feat: 타임리프 유틸리티 객체와 날짜 처리 기능 추가

### DIFF
--- a/src/main/java/hello/thymeleaf/basic/BasicController.java
+++ b/src/main/java/hello/thymeleaf/basic/BasicController.java
@@ -10,6 +10,7 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -64,6 +65,12 @@ public class BasicController {
         public String hello(String data) {
             return "Hello " + data;
         }
+    }
+
+    @GetMapping("/date")
+    public String date(Model model) {
+        model.addAttribute("localDateTime", LocalDateTime.now());
+        return "basic/date";
     }
 
     @Data

--- a/src/main/resources/templates/basic/date.html
+++ b/src/main/resources/templates/basic/date.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+
+<h1>LocalDateTime</h1>
+<ul>
+    <li>default = <span th:text="${localDateTime}"></span></li>
+    <li>yyyy-MM-dd HH:mm:ss =
+        <span th:text="${#temporals.format(localDateTime, 'yyyy-MM-dd HH:mm:ss')}"></span>
+    </li>
+</ul>
+
+<h1>LocalDateTime - Utils</h1>
+<ul>
+    <li>${#temporals.day(localDateTime)} =
+        <span th:text="${#temporals.day(localDateTime)}"></span>
+    </li>
+    <li>${#temporals.month(localDateTime)} =
+        <span th:text="${#temporals.month(localDateTime)}"></span>
+    </li>
+    <li>${#temporals.monthName(localDateTime)} =
+        <span th:text="${#temporals.monthName(localDateTime)}"></span>
+    </li>
+    <li>${#temporals.monthNameShort(localDateTime)} =
+        <span th:text="${#temporals.monthNameShort(localDateTime)}"></span>
+    </li>
+    <li>${#temporals.year(localDateTime)} =
+        <span th:text="${#temporals.year(localDateTime)}"></span>
+    </li>
+    <li>${#temporals.dayOfWeek(localDateTime)} =
+        <span th:text="${#temporals.dayOfWeek(localDateTime)}"></span>
+    </li>
+    <li>${#temporals.dayOfWeekName(localDateTime)} =
+        <span th:text="${#temporals.dayOfWeekName(localDateTime)}"></span>
+    </li>
+    <li>${#temporals.dayOfWeekNameShort(localDateTime)} =
+        <span th:text="${#temporals.dayOfWeekNameShort(localDateTime)}"></span>
+    </li>
+    <li>${#temporals.hour(localDateTime)} =
+        <span th:text="${#temporals.hour(localDateTime)}"></span>
+    </li>
+    <li>${#temporals.minute(localDateTime)} =
+        <span th:text="${#temporals.minute(localDateTime)}"></span>
+    </li>
+    <li>${#temporals.second(localDateTime)} =
+        <span th:text="${#temporals.second(localDateTime)}"></span>
+    </li>
+    <li>${#temporals.nanosecond(localDateTime)} =
+        <span th:text="${#temporals.nanosecond(localDateTime)}"></span>
+    </li>
+</ul>
+
+</body>
+</html>


### PR DESCRIPTION
#### 작업 내용
- 타임리프에서 제공하는 유틸리티 객체 목록 정리 (`#temporals`, `#strings`, `#numbers` 등)
- 자바 8 날짜 출력용 `/date` 요청 핸들러 추가
- `LocalDateTime.now()`를 모델에 담아 템플릿에서 다양한 포맷으로 출력
- `basic/date.html`에 temporals 유틸리티를 활용한 날짜 출력 예제 구현
