### PR TITLE
feat: 타임리프 주석 및 블록 태그 예제 추가

### DIFF
--- a/src/main/java/hello/thymeleaf/basic/BasicController.java
+++ b/src/main/java/hello/thymeleaf/basic/BasicController.java
@@ -112,6 +112,18 @@ public class BasicController {
         return "basic/condition";
     }
 
+    @GetMapping("comments")
+    public String comments(Model model) {
+        model.addAttribute("data", "Spring!");
+        return "basic/comments";
+    }
+
+    @GetMapping("/block")
+    public String block(Model model) {
+        addUsers(model);
+        return "basic/block";
+    }
+
     private void addUsers(Model model) {
         List<User> list = new ArrayList<>();
         list.add(new User("UserA", 10));

--- a/src/main/resources/templates/basic/block.html
+++ b/src/main/resources/templates/basic/block.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+<th:block th:each="user : ${users}">
+    <div>
+        사용자 이름1 <span th:text="${user.username}"></span>
+        사용자 나이1 <span th:text="${user.age}"></span>
+    </div>
+    <div>
+        요약 <span th:text="${user.username} + ' / ' + ${user.age}"></span>
+    </div>
+</th:block>
+</body>
+</html>

--- a/src/main/resources/templates/basic/comments.html
+++ b/src/main/resources/templates/basic/comments.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+<h1>예시</h1>
+<span th:text="${data}">html data</span>
+<h1>1. 표준 HTML 주석</h1>
+<!--
+<span th:text="${data}">html data</span>
+-->
+<h1>2. 타임리프 파서 주석</h1>
+<!--/* [[${data}]] */-->
+<!--/*-->
+<span th:text="${data}">html data</span>
+<!--*/-->
+<h1>3. 타임리프 프로토타입 주석</h1>
+<!--/*/
+/*/-->
+<span th:text="${data}">html data</span>
+</body>
+</html>


### PR DESCRIPTION
### 주요 변경 사항
- `/comments`, `/block` 경로를 처리하는 컨트롤러 메서드 추가
- `comments.html` 템플릿 생성
  - 표준 HTML 주석, 타임리프 파서 주석, 프로토타입 주석 예제 포함
  - 각 주석 방식의 렌더링 결과 비교 가능
- `block.html` 템플릿 생성
  - `<th:block>`을 이용한 반복 처리 예제 작성
  - 태그 없이 반복 로직 적용 가능하며, 렌더링 시 `<th:block>` 제거됨
