### PR TITLE
템플릿 레이아웃에 코드 조각 전달 방식 적용

### DIFF
--- a/src/main/java/hello/thymeleaf/basic/TemplateController.java
+++ b/src/main/java/hello/thymeleaf/basic/TemplateController.java
@@ -11,4 +11,9 @@ public class TemplateController {
     public String template() {
         return "template/fragment/fragmentMain";
     }
+
+    @GetMapping("layout")
+    public String layout() {
+        return "template/layout/layoutMain";
+    }
 }

--- a/src/main/resources/templates/template/layout/base.html
+++ b/src/main/resources/templates/template/layout/base.html
@@ -1,0 +1,10 @@
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:fragment="common_header(title,links)">
+    <title th:replace="${title}">레이아웃 타이틀</title>
+    <!-- 공통 -->
+    <link rel="stylesheet" type="text/css" media="all" th:href="@{/css/awesomeapp.css}">
+    <link rel="shortcut icon" th:href="@{/images/favicon.ico}">
+    <script type="text/javascript" th:src="@{/sh/scripts/codebase.js}"></script>
+    <!-- 추가 -->
+    <th:block th:replace="${links}" />
+</head>

--- a/src/main/resources/templates/template/layout/layoutMain.html
+++ b/src/main/resources/templates/template/layout/layoutMain.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:replace="template/layout/base :: common_header(~{::title},~{::link})">
+    <title>메인 타이틀</title>
+    <link rel="stylesheet" th:href="@{/css/bootstrap.min.css}">
+    <link rel="stylesheet" th:href="@{/themes/smoothness/jquery-ui.css}">
+</head>
+<body>
+메인 컨텐츠
+</body>
+</html>


### PR DESCRIPTION
### 주요 변경 내용
- `base.html`에서 `<head>` 영역을 fragment로 분리 (`common_header(title, links)`)
- 각 페이지에서 사용하는 `<title>`, `<link>` 요소를 전달하여 동적 구성
- `th:replace`와 `~{::title}`, `~{::link}` 문법을 통해 레이아웃 유연성 확보
