### PR TITLE
전체 페이지 템플릿 레이아웃 확장 방식 적용

### DIFF
--- a/src/main/java/hello/thymeleaf/basic/TemplateController.java
+++ b/src/main/java/hello/thymeleaf/basic/TemplateController.java
@@ -16,4 +16,9 @@ public class TemplateController {
     public String layout() {
         return "template/layout/layoutMain";
     }
+
+    @GetMapping("/layoutExtend")
+    public String layoutExtend() {
+        return "template/layoutExtend/layoutExtendMain";
+    }
 }

--- a/src/main/resources/templates/template/layoutExtend/layoutExtendMain.html
+++ b/src/main/resources/templates/template/layoutExtend/layoutExtendMain.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html th:replace="~{template/layoutExtend/layoutFile :: layout(~{::title},~{::section})}"
+      xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>메인 페이지 타이틀</title>
+</head>
+<body>
+<section>
+    <p>메인 페이지 컨텐츠</p>
+    <div>메인 페이지 포함 내용</div>
+</section>
+</body>
+</html>

--- a/src/main/resources/templates/template/layoutExtend/layoutFile.html
+++ b/src/main/resources/templates/template/layoutExtend/layoutFile.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html th:fragment="layout (title, content)" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title th:replace="${title}">레이아웃 타이틀</title>
+</head>
+<body>
+<h1>레이아웃 H1</h1>
+<div th:replace="${content}">
+    <p>레이아웃 컨텐츠</p>
+</div>
+<footer>
+    레이아웃 푸터
+</footer>
+</body>
+</html>


### PR DESCRIPTION
### 주요 변경 내용
- `layoutFile.html`: 전체 HTML 문서에 대해 `th:fragment` 적용
- `layoutExtendMain.html`: `th:replace`를 사용해 레이아웃 확장 및 title, section 조각 전달
- title 및 content 영역에 동적으로 값 전달 가능
